### PR TITLE
Automagically disable loading when not on macOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,34 +1,29 @@
 # ZSH fast command-not-found plugin for macOS
 
-The purpose of this plugin is to provide a faster alternative to
+The purpose of this plugin is to provide a faster alternative to the
 `oh-my-zsh` / `prezto` one, which runs multiple useless checks, and
 runs `brew` command within `zshrc`.
 
 The problem is `brew` commands are really slow (0.5~2s) and cause
-huge zsh slowdown load time.
+a huge slowdown in zsh load time.
 
-This plugin check for `brew command-not-found` dynamically, when
-a wrong command has been typed. This cause a latency each time a
+This plugin checks for `brew command-not-found` dynamically, when
+a wrong command has been typed. This causes a latency each time a
 a not found command is typed.
+
 However, given the great auto-correction and syntax highlighting
 features of zsh, this is something that rarely happens, and which
 is less disturbing because we can stop it with <ctrl><v> easily.
-
 
 ## Installation
 
 You can use this plugin using zplug :
 
 ```bash
-zplug "Tireg/zsh-macos-command-not-found", if:"[[ "${OSTYPE}" == 'darwin'* ]]";
+zplug "Tireg/zsh-macos-command-not-found"
 ```
-
 
 ## Requirements
 
-This plugin is only meant to be sourced on macOS. Be sure to check
-your OS before sourcing it (like in Installation step with zplug)
-
 You should install [`brew`](https://brew.sh/index_fr), and tap
-[`homebrew/command-not-found`](https://github.com/Homebrew/homebrew-command-not-found)
-to make this plugin useful.
+[`homebrew/command-not-found`](https://github.com/Homebrew/homebrew-command-not-found) to make this plugin useful.

--- a/macos-command-not-found.plugin.zsh
+++ b/macos-command-not-found.plugin.zsh
@@ -8,40 +8,43 @@
 #       VERSION:  1.0.0
 # ------------------------------------------------------------------------------
 
-zstyle -t ':tireg:module:command-not-found' skip-brew;
-_SKIP_BREW="$?"
-
-if [ "${_SKIP_BREW}" -eq 2 ]; then
-	test -z "${CONTINUOUS_INTEGRATION}" \
-		&& ! test -n "${NC_SID}" -o ! -t 1 \
-		&& (( ${+commands[brew]} )) \
-		&& brew command which-formula 2>/dev/null >/dev/null \
-		&& zstyle ':tireg:module:command-not-found' skip-brew false \
-		|| zstyle ':tireg:module:command-not-found' skip-brew true;
-
+if [[ "$(uname -s)" = "Darwin" ]]; then
+	# Only load when we're running on macOS
 	zstyle -t ':tireg:module:command-not-found' skip-brew;
-	_SKIP_BREW="$?";
-fi
+	_SKIP_BREW="$?"
 
-if [ "${_SKIP_BREW}" -eq 1 ]; then
-	# Use brew
-	function command_not_found_handler() {
-		local cmd="$1";
-		# Brew command-not-found exists, so we can use it
-		local txt="$(brew which-formula --explain "${cmd}" 2>/dev/null)";
-		# If formula has been found, print instructions
-		[ ! -z "${txt}" ] && echo "${txt}" || {
+	if [ "${_SKIP_BREW}" -eq 2 ]; then
+		test -z "${CONTINUOUS_INTEGRATION}" \
+			&& ! test -n "${NC_SID}" -o ! -t 1 \
+			&& (( ${+commands[brew]} )) \
+			&& brew command which-formula 2>/dev/null >/dev/null \
+			&& zstyle ':tireg:module:command-not-found' skip-brew false \
+			|| zstyle ':tireg:module:command-not-found' skip-brew true;
+
+		zstyle -t ':tireg:module:command-not-found' skip-brew;
+		_SKIP_BREW="$?";
+	fi
+
+	if [ "${_SKIP_BREW}" -eq 1 ]; then
+		# Use brew
+		function command_not_found_handler() {
+			local cmd="$1";
+			# Brew command-not-found exists, so we can use it
+			local txt="$(brew which-formula --explain "${cmd}" 2>/dev/null)";
+			# If formula has been found, print instructions
+			[ ! -z "${txt}" ] && echo "${txt}" || {
+				[[ "${ZSH_VERSION}" > "5.2" ]] \
+					&& echo "zsh: command not found: ${cmd}";
+			};
+			return 127;
+		}
+	else
+		# Skip brew
+		function command_not_found_handler() {
+			local cmd="$1";
 			[[ "${ZSH_VERSION}" > "5.2" ]] \
 				&& echo "zsh: command not found: ${cmd}";
-		};
-		return 127;
-	}
-else
-	# Skip brew
-	function command_not_found_handler() {
-		local cmd="$1";
-		[[ "${ZSH_VERSION}" > "5.2" ]] \
-			&& echo "zsh: command not found: ${cmd}";
-		return 127;
-	}
+			return 127;
+		}
+	fi
 fi


### PR DESCRIPTION
* Check `uname` output during plugin load and only do the load when running on macOS. This lets you share an identical plugin setup across macOS/Linux/BSD without having to make OS-specific edits.
* Update README.md now that the plugin automatically handles OS detection